### PR TITLE
Add script to copy CT entries from one server to another

### DIFF
--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"flag"
+
+	logclient "github.com/google/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/jsonclient"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func main() {
+	var source string
+	var dest string
+	flag.StringVar(&source, "source", "localhost:6962", "The URL to the source CT server.")
+	flag.StringVar(&dest, "dest", "localhost:6962", "The URL to the destination CT server.")
+
+	flag.Parse()
+
+	client := http.DefaultClient
+	options := jsonclient.Options{}
+	ctx := context.Background()
+
+	log.Print("Creating clients...")
+	srcclient, err := logclient.New(source, client, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	destclient, err := logclient.New(dest, client, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sth, err := srcclient.GetSTH(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	numEntries := int64(sth.TreeSize)
+	// Limit # of entries for testing
+	if numEntries > 10 {
+		numEntries = 10
+	}
+
+	certs, err := srcclient.GetEntries(ctx, 0, numEntries)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, entry := range certs {
+		timestamp, err := destclient.AddChain(ctx, entry.Chain)
+		if err != nil {
+			log.Print("Error adding certificate:", err)
+		} else {
+			log.Print("Got timestamp:", timestamp)
+		}
+	}
+}


### PR DESCRIPTION
Currently can't get it to work with Trillian as a source, because you can't retrieve the STH or any entries.

Log output:

```
ct_server_1   | I0328 20:13:03.784781      11 handlers.go:104] {0}: request GET "/ct/v1/get-sth" => GetSTH
ct_server_1   | I0328 20:13:03.784922      11 handlers.go:358] {0}: GetSTH => grpc.GetLatestSignedLogRoot {LogId:0}
ct_server_1   | I0328 20:13:03.787224      11 handlers.go:360] {0}: GetSTH <= grpc.GetLatestSignedLogRoot err=<nil>
ct_server_1   | I0328 20:13:03.787257      11 handlers.go:370] {0}: GetSTH <= slr=
ct_server_1   | I0328 20:13:03.787288      11 handlers.go:126] {0}: GetSTH <= status=500
ct_server_1   | W0328 20:13:03.787302      11 handlers.go:133] {0}: GetSTH handler error: bad hash size from backend expecting: 32 got 0
```