### PR TITLE
Use the GOPATH that Go is definitely using

### DIFF
--- a/trillian/update-trillian.sh
+++ b/trillian/update-trillian.sh
@@ -4,12 +4,13 @@
 set -e
 
 COMPOSE_DIR=$(pwd)
+GOPATH=$(go env GOPATH)
 
 # Fetch Trillian and its dependencies
-# go get -d -v -u github.com/google/trillian
-# cd $GOPATH/src/github.com/google/trillian
-# go get -d -v -t ./...
-# CGO_ENABLED=0 GOOS=linux go build ./...
+go get -d -v -u github.com/google/trillian
+cd $GOPATH/src/github.com/google/trillian
+go get -d -v -t ./...
+CGO_ENABLED=0 GOOS=linux go build ./...
 
 cd $GOPATH/src/github.com/google/trillian
 cd examples/ct/ct_server


### PR DESCRIPTION
This is needed because Go 1.8 will use ~/go by default when GOPATH is unset.

Also, there has to be a way to check if Trillian has been installed, and if so, update, instead of rebuilding each time. Thoughts?